### PR TITLE
Sync with upstream - argosd, vibrator

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -270,10 +270,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.lineage.build.vendor_security_patch=2018-01-05
 
-# Vibrator
-PRODUCT_PACKAGES += \
-    android.hardware.vibrator@1.0-impl
-
 # VNDK
 # Patch/hexedit DRM to look for older version of libprotobuf-cpp-lite.so
 PRODUCT_COPY_FILES += \

--- a/manifest.xml
+++ b/manifest.xml
@@ -202,15 +202,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.vibrator</name>
-        <transport arch="32">passthrough</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IVibrator</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>vendor.lineage.livedisplay</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/rootdir/etc/init.universal5433.rc
+++ b/rootdir/etc/init.universal5433.rc
@@ -631,9 +631,8 @@ service gpsd /vendor/bin/gpsd -c /vendor/etc/gps.xml
     group system inet net_raw
     ioprio be 0
 
-# Why do we need this on S2 wifi only devices?  If needed for LTE, decommonize this code.
 # ARGOSD
-#service argos-daemon /vendor/bin/argosd
-#    class main
-#    user system
-#    group system radio
+service argos-daemon /vendor/bin/argosd
+    class main
+    user system
+    group system radio

--- a/sepolicy-rt/argosd.te
+++ b/sepolicy-rt/argosd.te
@@ -1,0 +1,29 @@
+# argosd.te
+
+type argosd, domain;
+type argosd_exec, exec_type, vendor_file_type, file_type;
+
+# argosd is started by init, type transit from init domain to gpsd domain
+init_daemon_domain(argosd)
+
+# /dev/network_throughput
+allow argosd radio_qos_device:chr_file rw_file_perms;
+
+# /proc/net/dev
+allow argosd proc_net:file r_file_perms;
+
+# /sys/
+allow argosd sysfs:dir r_dir_perms;
+allow argosd sysfs:file r_file_perms;
+
+# /sys/devices/platform/argos
+# /sys/firmware/devicetree/base/argos
+allow argosd sysfs_argos:dir r_dir_perms;
+allow argosd sysfs_argos:file r_file_perms;
+
+# /sys/class/scsi_host/host0
+allow argosd sysfs_scsi_host_writable:dir r_dir_perms;
+allow argosd sysfs_scsi_host_writable:file r_file_perms;
+
+allow argosd proc:file r_file_perms;
+allow argosd proc_stat:file r_file_perms;

--- a/sepolicy-rt/attributes
+++ b/sepolicy-rt/attributes
@@ -1,0 +1,8 @@
+# Tag for read only filesystem type
+attribute r_fs_type;
+
+# Tag for read/write filesystem type
+attribute rw_fs_type;
+
+# Tag for read/execute filesystem type
+attribute rx_fs_type;

--- a/sepolicy-rt/device.te
+++ b/sepolicy-rt/device.te
@@ -1,6 +1,9 @@
 # /dev/ttySAC3
 type bluetooth_device, dev_type;
 
+# for argosd
+type radio_qos_device, dev_type;
+
 # /dev/s5p-smem
 type secmem_device, dev_type;
 

--- a/sepolicy-rt/file.te
+++ b/sepolicy-rt/file.te
@@ -44,6 +44,7 @@ type proc_vm, fs_type, proc_type;
 type proc_wifiloader, fs_type, proc_type;
 
 # sysfs types
+type sysfs_argos, sysfs_type, r_fs_type, fs_type;
 type sysfs_ausb, fs_type, sysfs_type, mlstrustedobject;
 type sysfs_camera, fs_type, sysfs_type, mlstrustedobject;
 type sysfs_cpuidle_writable, fs_type, sysfs_type, mlstrustedobject;
@@ -67,6 +68,8 @@ type sysfs_muic, fs_type, sysfs_type, mlstrustedobject;
 type sysfs_multipdp_writable, fs_type, sysfs_type, mlstrustedobject;
 
 type sysfs_power_writable, fs_type, sysfs_type, mlstrustedobject;
+
+type sysfs_scsi_host_writable, sysfs_type, rw_fs_type, fs_type;
 
 type sysfs_sec_switch, fs_type, sysfs_type, mlstrustedobject;
 

--- a/sepolicy-rt/file_contexts
+++ b/sepolicy-rt/file_contexts
@@ -42,6 +42,9 @@
 /dev/block/mmcblk0p20        u:object_r:cache_block_device:s0
 /dev/block/mmcblk0p22        u:object_r:userdata_block_device:s0
 
+### qos
+/dev/network_throughput                      u:object_r:radio_qos_device:s0
+
 # Secure
 /dev/s5p-smem                u:object_r:secmem_device:s0
 /dev/mobicore                u:object_r:tee_device:s0
@@ -53,6 +56,7 @@
 # Daemons
 #
 
+/(vendor|system/vendor)/bin/argosd														 u:object_r:argosd_exec:s0
 /(vendor|system/vendor)/bin/gpsd                                                         u:object_r:gpsd_exec:s0
 /(vendor|system/vendor)/bin/wifiloader                                                   u:object_r:wifiloader_exec:s0
 /(vendor|system/vendor)/bin/mcDriverDaemon                                               u:object_r:tee_exec:s0

--- a/sepolicy-rt/genfs_contexts
+++ b/sepolicy-rt/genfs_contexts
@@ -1,11 +1,15 @@
 # CPU/Scheduler devices
-#genfscon sysfs /power/cpufreq_table         u:object_r:sysfs_devices_system_cpu:s0
-genfscon sysfs /power/cpufreq_min_limit     u:object_r:sysfs_devices_system_cpu:s0
-genfscon sysfs /power/cpufreq_max_limit     u:object_r:sysfs_devices_system_cpu:s0
+#genfscon sysfs /power/cpufreq_table			u:object_r:sysfs_devices_system_cpu:s0
+genfscon sysfs /power/cpufreq_min_limit			u:object_r:sysfs_devices_system_cpu:s0
+genfscon sysfs /power/cpufreq_max_limit			u:object_r:sysfs_devices_system_cpu:s0
 
 # CPU/Scheduler devices
-genfscon sysfs /power/cpufreq_table                       u:object_r:sysfs_power_writable:s0
-genfscon sysfs /module/cpuidle/parameters/off             u:object_r:sysfs_cpuidle_writable:s0
+genfscon sysfs /power/cpufreq_table             u:object_r:sysfs_power_writable:s0
+genfscon sysfs /module/cpuidle/parameters/off   u:object_r:sysfs_cpuidle_writable:s0
+
+# Qos for argosd
+genfscon sysfs /devices/platform/argosd			u:object_r:sysfs_argos:s0
+
 
 # Storaged
 # https://review.lineageos.org/c/LineageOS/android_system_sepolicy/+/264057


### PR DESCRIPTION
Sync with upstream to add argosd selinux support, de-commonalization of vibrator.