### PR TITLE
gts2-common: address more sepolicy denials

### DIFF
--- a/sepolicy/vendor/gpsd.te
+++ b/sepolicy/vendor/gpsd.te
@@ -39,7 +39,7 @@ allow gpsd node:tcp_socket node_bind;
 allow gpsd self:tcp_socket create_socket_perms;
 allow gpsd sensorservice_service:service_manager find;
 allow gpsd servicemanager:binder call;
-allow gpsd shell_exec:file execute;
+allow gpsd shell_exec:file rx_file_perms;
 allow gpsd sysfs:file rw_file_perms;
 allow gpsd system_data_file:dir w_dir_perms;
 allow gpsd system_data_file:fifo_file rw_file_perms;

--- a/sepolicy/vendor/hal_sensors_default.te
+++ b/sepolicy/vendor/hal_sensors_default.te
@@ -11,4 +11,5 @@ allow hal_sensors_default sysfs_input:file rw_file_perms;
 allow hal_sensors_default sysfs_input:lnk_file r_file_perms;
 allow hal_sensors_default system_data_file:dir w_dir_perms;
 allow hal_sensors_default system_data_file:file create_file_perms;
+allow hal_sensors_default system_data_root_file:dir w_dir_perms;
 allow hal_sensors_default system_data_root_file:file rw_file_perms;

--- a/sepolicy/vendor/netd.te
+++ b/sepolicy/vendor/netd.te
@@ -1,3 +1,4 @@
 #============= netd ==============
 allow netd gpsd:fd use;
 allow netd gpsd:tcp_socket rw_socket_perms_no_ioctl;
+allow netd sysfs:file w_file_perms;

--- a/sepolicy/vendor/system_app.te
+++ b/sepolicy/vendor/system_app.te
@@ -1,6 +1,6 @@
 #============= system_app ==============
 allow system_app device:chr_file rw_file_perms;
-allow system_app proc_pagetypeinfo:file read;
+allow system_app proc_pagetypeinfo:file r_file_perms;
 allow system_app sysfs:dir { open read };
 allow system_app sysfs:file r_file_perms;
 


### PR DESCRIPTION
xda user Yogi555 submitted these logs.

02-01 22:52:29.864  4634  4634 I auditd  : type=1400 audit(0.0:4072): avc: denied { write } for comm="binder:3500_6" name="mtu" dev="sysfs" ino=18407 scontext=u:r:netd:s0 tcontext=u:object_r:sysfs:s0 tclass=file
02-01 22:52:29.864  4634  4634 I auditd  : type=1300 audit(0.0:4072): arch=40000028 syscall=322 per=800008 success=no exit=-13 a0=ffffff9c a1=a97fcb00 a2=a8241 a3=1b6 items=3 ppid=1 ppcomm=init auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 ses=4294967295 tty=(none) comm="binder:3500_6" exe="/system/bin/netd" subj=u:r:netd:s0 key=(null)
02-01 22:52:29.864  3277  3356 I auditd  : type=1307 audit(0.0:4072): cwd="/"
02-01 22:52:29.864  3277  3356 I auditd  : type=1302 audit(0.0:4072): item=0 name="/sys/class/net/wlan0/" inode=18388 dev=00:0f mode=040755 ouid=0 ogid=0 rdev=00:00 obj=u:object_r:sysfs:s0
02-01 22:52:29.864  3277  3356 I auditd  : type=1302 audit(0.0:4072): item=1 name=(null) inode=18407 dev=00:0f mode=0100644 ouid=0 ogid=0 rdev=00:00 obj=u:object_r:sysfs:s0

02-01 20:57:35.839  3523  3523 I auditd  : type=1400 audit(0.0:3990): avc: denied { write } for comm="sensors@1.0-ser" name="/" dev="mmcblk0p22" ino=2 scontext=u:r:hal_sensors_default:s0 tcontext=u:object_r:system_data_root_file:s0 tclass=dir
02-01 20:57:35.839  3523  3523 I auditd  : type=1300 audit(0.0:3990): arch=40000028 syscall=322 per=800008 success=no exit=-13 a0=ffffff9c a1=aa272774 a2=20242 a3=1b6 items=2 ppid=1 ppcomm=init auid=4294967295 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 ses=4294967295 tty=(none) comm="sensors@1.0-ser" exe="/system/vendor/bin/hw/android.hardware.sensors@1.0-service" subj=u:r:hal_sensors_default:s0 key=(null)
02-01 20:57:35.839  3277  3356 I auditd  : type=1307 audit(0.0:3990): cwd="/"
02-01 20:57:35.839  3277  3356 I auditd  : type=1302 audit(0.0:3990): item=0 name="/data/" inode=2 dev=103:0e mode=040771 ouid=1000 ogid=1000 rdev=00:00 obj=u:object_r:system_data_root_file:s0
02-01 20:57:35.839  3277  3356 I auditd  : type=1302 audit(0.0:3990): item=1 name="/data/iNemoEngine_gbias.dat"

02-01 21:03:28.564  1876  1876 I auditd  : type=1400 audit(0.0:3996): avc: denied { open } for comm="ndroid.settings" path="/proc/pagetypeinfo" dev="proc" ino=4026541026 scontext=u:r:system_app:s0 tcontext=u:object_r:proc_pagetypeinfo:s0 tclass=file
02-01 21:03:28.564  1876  1876 I auditd  : type=1300 audit(0.0:3996): arch=40000028 syscall=322 per=800008 success=no exit=-13 a0=ffffff9c a1=7e434b68 a2=20000 a3=0 items=1 ppid=3501 ppcomm=main auid=4294967295 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 ses=4294967295 tty=(none) comm="ndroid.settings" exe="/system/bin/app_process32" subj=u:r:system_app:s0 key=(null)
02-01 21:03:28.564  3277  3356 I auditd  : type=1307 audit(0.0:3996): cwd="/"
02-01 21:03:28.564  3277  3356 I auditd  : type=1302 audit(0.0:3996): item=0 name="/proc/pagetypeinfo" inode=4026541026 dev=00:03 mode=0100440 ouid=0 ogid=1007 rdev=00:00 obj=u:object_r:proc_pagetypeinfo:s0
02-01 21:03:28.564  3277  3356 I auditd  : type=1327 audit(0.0:3996): proctitle="com.android.settings"

02-01 20:57:50.814  1220  1220 I auditd  : type=1400 audit(0.0:3991): avc: denied { read open } for comm="gpsd" path="/system/bin/sh" dev="mmcblk0p19" ino=1083 scontext=u:r:gpsd:s0 tcontext=u:object_r:shell_exec:s0 tclass=file
02-01 20:57:50.814  1220  1220 I auditd  : type=1300 audit(0.0:3991): arch=40000028 syscall=11 per=800008 success=no exit=-13 a0=a67697f0 a1=befa5968 a2=befa60f4 a3=befa5974 items=1 ppid=3563 ppcomm=gpsd auid=4294967295 uid=1021 gid=1000 euid=1021 suid=1021 fsuid=1021 egid=1000 sgid=1000 fsgid=1000 ses=4294967295 tty=(none) comm="gpsd" exe="/system/vendor/bin/gpsd" subj=u:r:gpsd:s0 key=(null)
02-01 20:57:50.814  3277  3356 I auditd  : type=1307 audit(0.0:3991): cwd="/"
02-01 20:57:50.814  3277  3356 I auditd  : type=1302 audit(0.0:3991): item=0 name="/system/bin/sh" inode=1083 dev=103:0b mode=0100755 ouid=0 ogid=2000 rdev=00:00 obj=u:object_r:shell_exec:s0
02-01 20:57:50.814  3277  3356 I auditd  : type=1327 audit(0.0:3991): proctitle=2F76656E646F722F62696E2F67707364002D63002F76656E646F722F6574632F6770732E786D6C

02-01 23:24:07.384  3563  3563 I auditd  : type=1400 audit(0.0:4094): avc: denied { search } for comm="gpsd" name="data" dev="mmcblk0p22" ino=505921 scontext=u:r:gpsd:s0 tcontext=u:object_r:system_data_file:s0:c512,c768 tclass=dir
02-01 23:24:07.384  3563  3563 I auditd  : type=1300 audit(0.0:4094): arch=40000028 syscall=322 per=800008 success=no exit=-13 a0=ffffff9c a1=a8571008 a2=a4000 a3=0 items=1 ppid=1 ppcomm=init auid=4294967295 uid=1021 gid=1000 euid=1021 suid=1021 fsuid=1021 egid=1000 sgid=1000 fsgid=1000 ses=4294967295 tty=(none) comm="gpsd" exe="/system/vendor/bin/gpsd" subj=u:r:gpsd:s0 key=(null)
02-01 23:24:07.384  3277  3356 I auditd  : type=1307 audit(0.0:4094): cwd="/"